### PR TITLE
Add rimraf and remove del

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ var concat = require('gulp-concat');
 var compass = require('gulp-compass');
 var minifycss = require('gulp-minify-css');
 var uglify = require('gulp-uglify');
-var del = require('del');
+var rimraf = require('rimraf');
 
 var paths = {
     vendors: [
@@ -40,7 +40,7 @@ var paths = {
 
 // cleanup the build folder
 gulp.task('clean', function(cb) {
-    del(['web/build'], cb);
+    rimraf('web/build/**/*.*', cb);
 });
 
 gulp.task('js-vendor', function() {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "gulp-minify-css": "~0.3.10",
     "gulp-compass": "~1.3.2",
     "gulp-uglify": "~1.0.1",
-    "del": "~0.1.3"
+    "rimraf": "~2.2.8"
   }
 }


### PR DESCRIPTION
Rimraf allow to remove a non-empty folder.

This will fix error like:

```
[12:14:47] 'clean' errored after 1.22 s
[12:14:47] Error: ENOTEMPTY, rmdir 'web/build'
```
