### PR TITLE
Composer improvments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,8 @@
     "license": "MIT",
     "type": "project",
     "autoload": {
-        "psr-4": {
-            "Api43\\": "src"
-        }
+        "psr-4": { "Api43\\": "src" },
+        "exclude-from-classmap": ["/Tests/"]
     },
     "authors": [
         {
@@ -43,19 +42,18 @@
         "symfony/phpunit-bridge": "~2.7.0"
     },
     "scripts": {
-        "post-install-cmd": [
+        "post-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
         ],
+        "post-install-cmd": [
+            "@post-cmd"
+        ],
         "post-update-cmd": [
-            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
+            "@post-cmd"
         ]
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d43db64ae242bda4c1233c2593b15d82",
+    "hash": "4f153649e7997fbce8cbc8398fc935d3",
     "content-hash": "8b947844fb28e4ef8f28432b80fc4c2d",
     "packages": [
         {
@@ -161,16 +161,16 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.5.2",
+            "version": "v1.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "47c7128262da274f590ae6f86eb137a7a64e82af"
+                "reference": "47cdc76ceb95cc591d9c79a36dc3794975b5d136"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/47c7128262da274f590ae6f86eb137a7a64e82af",
-                "reference": "47c7128262da274f590ae6f86eb137a7a64e82af",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/47cdc76ceb95cc591d9c79a36dc3794975b5d136",
+                "reference": "47cdc76ceb95cc591d9c79a36dc3794975b5d136",
                 "shasum": ""
             },
             "require": {
@@ -227,7 +227,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-03 10:50:37"
+            "time": "2015-12-19 05:03:47"
         },
         {
             "name": "doctrine/collections",
@@ -3225,16 +3225,16 @@
         },
         {
             "name": "sensio/framework-extra-bundle",
-            "version": "v3.0.11",
+            "version": "v3.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-                "reference": "a79e205737b58d557c05caef6dfa8f94d8084bca"
+                "reference": "3e8936fe13aa4086644977d334d8fcd275f50357"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/a79e205737b58d557c05caef6dfa8f94d8084bca",
-                "reference": "a79e205737b58d557c05caef6dfa8f94d8084bca",
+                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/3e8936fe13aa4086644977d334d8fcd275f50357",
+                "reference": "3e8936fe13aa4086644977d334d8fcd275f50357",
                 "shasum": ""
             },
             "require": {
@@ -3276,7 +3276,7 @@
                 "annotations",
                 "controllers"
             ],
-            "time": "2015-10-28 15:47:04"
+            "time": "2015-12-18 17:39:27"
         },
         {
             "name": "sensio/generator-bundle",

--- a/src/FeedBundle/Controller/FeedTestController.php
+++ b/src/FeedBundle/Controller/FeedTestController.php
@@ -33,10 +33,16 @@ class FeedTestController extends Controller
             // add ability to test a siteconfig before submitting it
             $siteConfig = $form->get('siteconfig')->getData();
             if (trim($siteConfig)) {
-                $url = parse_url($form->get('link')->getData(), PHP_URL_HOST);
+                $host = parse_url($form->get('link')->getData(), PHP_URL_HOST);
 
-                if ($url) {
-                    $filePath = $this->getParameter('kernel.root_dir').'/site_config/'.$url.'.txt';
+                if ($host) {
+                    // remove www. from host because graby check for domain (without www.) first
+                    $host = strtolower($host);
+                    if (stripos($host, 'www.') === 0) {
+                        $host = substr($host, 4);
+                    }
+
+                    $filePath = $this->getParameter('kernel.root_dir').'/site_config/'.$host.'.txt';
                     file_put_contents($filePath, $siteConfig);
                 }
             }


### PR DESCRIPTION
Following great article from Jordi: http://seld.be/notes/new-composer-patterns

Also fix an error with siteconfig testing.
> Graby use the host without `www.` first. So we need to remove it.
In case of a subdomain (like `m.example.com`), it's not a problem: graby will check for a file with `m.example.com`, then a file with `example.com`.