### PR TITLE
Add Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Anyway, it's simple:
 
 ## Workflow
 
-When it grabs a new item, there are several steps before we can say the item *is* readable. Let me introduce **improvers**, **extractors** and **parsers**.
+When it grabs a new item, there are several steps before we can say the item *is* readable. Let me introduce **improvers**, **extractors**, **converters** and **parsers**.
 
 All of them works in a chain, we'll go thru all of them until we find one that match.
 
-> For curious people, this workflow happen in the [`Proxy->parseContent`](https://github.com/j0k3r/f43.me/blob/915b77a1a209e6ca64fcd30e5078f6c92eea9abe/src/j0k3r/FeedBundle/Readability/Proxy.php#L64-L117) method.
+> For curious people, this workflow happen in the [`Extractor->parseContent`](https://github.com/j0k3r/f43.me/blob/000dd43db9ab4429344918a2263bee3bf8aace24/src/FeedBundle/Content/Extractor.php#L68) method.
 
 ### Improvers
 
@@ -59,12 +59,20 @@ You can find some of them in the [extractor folder](https://github.com/j0k3r/f43
 
 ### Parsers
 
-And finally, when we have the (most of the time, little) content from the feed, we use parsers to grab the html from the url and make it readable.
+When we have the (most of the time, little) content from the feed, we use parsers to grab the html from the url and make it readable.
 
 This involve 2 kind of parser:
 
  * the **Internal**, which uses a local PHP libray, called [graby](https://github.com/j0k3r/graby).
  * the **External**, which uses the excellent [Mercury Web Parser API](https://mercury.postlight.com/web-parser/) from Postlight Labs.
+
+### Converters
+
+And finally, we can use some converters to transform HTML code to something different.
+
+For example, Instagram embed code doesn't include the image itself (this part is usually done in javascript). The Instagram converter use the Instagram extractor to retrieve the image of an embed code and put it back in the feed item content.
+
+You can find some of them in the [converter folder](https://github.com/j0k3r/f43.me/tree/master/src/FeedBundle/Converter) (only Instagram for the moment)
 
 ## How to use it
 

--- a/src/FeedBundle/Api43FeedBundle.php
+++ b/src/FeedBundle/Api43FeedBundle.php
@@ -2,6 +2,7 @@
 
 namespace Api43\FeedBundle;
 
+use Api43\FeedBundle\Converter\ConverterCompilerPass;
 use Api43\FeedBundle\Extractor\ExtractorCompilerPass;
 use Api43\FeedBundle\Improver\ImproverCompilerPass;
 use Api43\FeedBundle\Parser\ParserCompilerPass;
@@ -15,6 +16,7 @@ class Api43FeedBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new ExtractorCompilerPass());
+        $container->addCompilerPass(new ConverterCompilerPass());
         $container->addCompilerPass(new ImproverCompilerPass());
         $container->addCompilerPass(new ParserCompilerPass());
     }

--- a/src/FeedBundle/Content/Extractor.php
+++ b/src/FeedBundle/Content/Extractor.php
@@ -13,6 +13,7 @@ class Extractor
     protected $feed = null;
     protected $extractorChain;
     protected $improverChain;
+    protected $converterChain;
     protected $parserChain;
     protected $parser;
     protected $allowAllParser = false;
@@ -114,7 +115,7 @@ class Extractor
             $this->content = $improver->updateContent($this->content);
         }
 
-        // try to find a custom converter to convert some html
+        // give content to each converter to convert some html into a better one
         $this->content = $this->converterChain->convert($this->content);
 
         return $this;

--- a/src/FeedBundle/Content/Extractor.php
+++ b/src/FeedBundle/Content/Extractor.php
@@ -2,6 +2,7 @@
 
 namespace Api43\FeedBundle\Content;
 
+use Api43\FeedBundle\Converter\ConverterChain;
 use Api43\FeedBundle\Document\Feed;
 use Api43\FeedBundle\Extractor\ExtractorChain;
 use Api43\FeedBundle\Improver\ImproverChain;
@@ -25,12 +26,14 @@ class Extractor
      *
      * @param ExtractorChain $extractorChain
      * @param ImproverChain  $improverChain
+     * @param ConverterChain $converterChain
      * @param ParserChain    $parserChain
      */
-    public function __construct(ExtractorChain $extractorChain, ImproverChain $improverChain, ParserChain $parserChain)
+    public function __construct(ExtractorChain $extractorChain, ImproverChain $improverChain, ConverterChain $converterChain, ParserChain $parserChain)
     {
         $this->extractorChain = $extractorChain;
         $this->improverChain = $improverChain;
+        $this->converterChain = $converterChain;
         $this->parserChain = $parserChain;
     }
 
@@ -110,6 +113,9 @@ class Extractor
             // update readable content with something ?
             $this->content = $improver->updateContent($this->content);
         }
+
+        // try to find a custom converter to convert some html
+        $this->content = $this->converterChain->convert($this->content);
 
         return $this;
     }

--- a/src/FeedBundle/Converter/AbstractConverter.php
+++ b/src/FeedBundle/Converter/AbstractConverter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Api43\FeedBundle\Converter;
+
+use GuzzleHttp\Client;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+
+abstract class AbstractConverter implements LoggerAwareInterface
+{
+    protected $logger;
+    protected $client;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param Client $client
+     */
+    public function setClient(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Will convert the html into what they want.
+     * If it hasn't modified, it'll return right away.
+     *
+     * @param string $html
+     *
+     * @return string
+     */
+    abstract public function convert($html);
+}

--- a/src/FeedBundle/Converter/AbstractConverter.php
+++ b/src/FeedBundle/Converter/AbstractConverter.php
@@ -2,14 +2,12 @@
 
 namespace Api43\FeedBundle\Converter;
 
-use GuzzleHttp\Client;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 
 abstract class AbstractConverter implements LoggerAwareInterface
 {
     protected $logger;
-    protected $client;
 
     /**
      * {@inheritdoc}
@@ -17,14 +15,6 @@ abstract class AbstractConverter implements LoggerAwareInterface
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
-    }
-
-    /**
-     * @param Client $client
-     */
-    public function setClient(Client $client)
-    {
-        $this->client = $client;
     }
 
     /**

--- a/src/FeedBundle/Converter/ConverterChain.php
+++ b/src/FeedBundle/Converter/ConverterChain.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Api43\FeedBundle\Converter;
+
+class ConverterChain
+{
+    private $converters;
+
+    public function __construct()
+    {
+        $this->converters = [];
+    }
+
+    /**
+     * Add an converter to the chain.
+     *
+     * @param AbstractConverter $converter
+     * @param string            $alias
+     */
+    public function addConverter(AbstractConverter $converter, $alias)
+    {
+        $this->converters[$alias] = $converter;
+    }
+
+    /**
+     * Loop thru all converter and convert content.
+     *
+     * @param string $html Article content
+     *
+     * @return string
+     */
+    public function convert($html)
+    {
+        foreach ($this->converters as $converter) {
+            $html = $converter->convert($html);
+        }
+
+        return $html;
+    }
+}

--- a/src/FeedBundle/Converter/ConverterCompilerPass.php
+++ b/src/FeedBundle/Converter/ConverterCompilerPass.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Api43\FeedBundle\Converter;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ConverterCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('feed.converter.chain')) {
+            return;
+        }
+
+        $definition = $container->getDefinition(
+            'feed.converter.chain'
+        );
+
+        $taggedServices = $container->findTaggedServiceIds(
+            'feed.converter'
+        );
+        foreach ($taggedServices as $id => $tagAttributes) {
+            foreach ($tagAttributes as $attributes) {
+                $definition->addMethodCall(
+                    'addConverter',
+                    [new Reference($id), $attributes['alias']]
+                );
+            }
+        }
+    }
+}

--- a/src/FeedBundle/Converter/Instagram.php
+++ b/src/FeedBundle/Converter/Instagram.php
@@ -40,6 +40,10 @@ class Instagram extends AbstractConverter
             $this->instagramExtractor->match('https://www.instagram.com/p' . $instagramId);
             $image = $this->instagramExtractor->getImageOnly();
 
+            if (strlen($image) === 0) {
+                continue;
+            }
+
             $newContent = str_replace('image_url', $image, self::IMAGE_CONTENT);
 
             $html = str_replace($matches[0][$key], $newContent . $matches[0][$key], $html);

--- a/src/FeedBundle/Converter/Instagram.php
+++ b/src/FeedBundle/Converter/Instagram.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Api43\FeedBundle\Converter;
+
+use Api43\FeedBundle\Extractor\Instagram as InstagramExtractor;
+
+/**
+ * This converter will try to change embed html from Instagram from a simple html code to a real image to be displayed.
+ */
+class Instagram extends AbstractConverter
+{
+    const IMAGE_CONTENT = '<img src="image_url" /></p><p>';
+
+    private $instagramExtractor;
+
+    public function __construct(InstagramExtractor $instagramExtractor)
+    {
+        $this->instagramExtractor = $instagramExtractor;
+    }
+
+    /**
+     * This will convert all instagram embed to real image.
+     * The detection is a bit ugly because it's done using a regex to find instagram content.
+     * Mostly because html shouldn't be valid.
+     *
+     * @param string $html
+     *
+     * @return string
+     */
+    public function convert($html)
+    {
+        $re = '/<a href\=\"https\:\/\/www.instagram.com\/p([0-9a-z-_:\/\.]+)\"/i';
+        $res = preg_match_all($re, $html, $matches);
+
+        if (false === $res || $res < 1) {
+            return $html;
+        }
+
+        foreach ($matches[1] as $key => $instagramId) {
+            $this->instagramExtractor->match('https://www.instagram.com/p' . $instagramId);
+            $image = $this->instagramExtractor->getImageOnly();
+
+            $newContent = str_replace('image_url', $image, self::IMAGE_CONTENT);
+
+            $html = str_replace($matches[0][$key], $newContent . $matches[0][$key], $html);
+        }
+
+        return $html;
+    }
+}

--- a/src/FeedBundle/Extractor/ExtractorChain.php
+++ b/src/FeedBundle/Extractor/ExtractorChain.php
@@ -12,7 +12,7 @@ class ExtractorChain
     }
 
     /**
-     * Add an extrator to the chain.
+     * Add an extractor to the chain.
      *
      * @param AbstractExtractor $extractor
      * @param string            $alias

--- a/src/FeedBundle/Extractor/Instagram.php
+++ b/src/FeedBundle/Extractor/Instagram.php
@@ -35,6 +35,26 @@ class Instagram extends AbstractExtractor
     }
 
     /**
+     * Fetch content from Instagram about an url.
+     *
+     * @return array|false
+     */
+    private function retrieveData()
+    {
+        try {
+            return $this->client
+                ->get('https://api.instagram.com/oembed?url=' . $this->instagramUrl)
+                ->json();
+        } catch (RequestException $e) {
+            $this->logger->warning('Instagram extract failed for: ' . $this->instagramUrl, [
+                'exception' => $e,
+            ]);
+
+            return false;
+        }
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getContent()
@@ -43,22 +63,29 @@ class Instagram extends AbstractExtractor
             return '';
         }
 
-        try {
-            $data = $this->client
-                ->get('https://api.instagram.com/oembed?url=' . $this->instagramUrl)
-                ->json();
-        } catch (RequestException $e) {
-            $this->logger->warning('Instagram extract failed for: ' . $this->instagramUrl, [
-                'exception' => $e,
-            ]);
-
-            return '';
-        }
+        $data = $this->retrieveData();
 
         if (!is_array($data) || empty($data)) {
             return '';
         }
 
         return '<div><h2>' . $data['title'] . '</h2><p><img src="' . $data['thumbnail_url'] . '"></p>' . $data['html'] . '</div>';
+    }
+
+    /**
+     * Return only the image instead of the whole html content.
+     * Used in the Instagram converter.
+     *
+     * @return string
+     */
+    public function getImageOnly()
+    {
+        $data = $this->retrieveData();
+
+        if (!is_array($data) || empty($data)) {
+            return '';
+        }
+
+        return $data['thumbnail_url'];
     }
 }

--- a/src/FeedBundle/Resources/config/converters.yml
+++ b/src/FeedBundle/Resources/config/converters.yml
@@ -1,0 +1,14 @@
+services:
+    # feed converter
+    feed.converter.chain:
+        class: Api43\FeedBundle\Converter\ConverterChain
+
+    feed.converter.instagram:
+        class: Api43\FeedBundle\Converter\Instagram
+        arguments:
+            - "@feed.extractor.instagram"
+        calls:
+            - [ setLogger, [ "@logger" ]]
+            - [ setClient, [ "@guzzle.client" ]]
+        tags:
+            -  { name: feed.converter, alias: instagram }

--- a/src/FeedBundle/Resources/config/converters.yml
+++ b/src/FeedBundle/Resources/config/converters.yml
@@ -9,6 +9,5 @@ services:
             - "@feed.extractor.instagram"
         calls:
             - [ setLogger, [ "@logger" ]]
-            - [ setClient, [ "@guzzle.client" ]]
         tags:
             -  { name: feed.converter, alias: instagram }

--- a/src/FeedBundle/Resources/config/services.yml
+++ b/src/FeedBundle/Resources/config/services.yml
@@ -1,6 +1,7 @@
 imports:
     - { resource: extractors.yml }
     - { resource: improvers.yml }
+    - { resource: converters.yml }
     - { resource: parsers.yml }
 
 services:
@@ -68,6 +69,7 @@ services:
         arguments:
             extractor: "@feed.extractor.chain"
             improver: "@feed.improver.chain"
+            converter: "@feed.converter.chain"
             parser: "@feed.parser.chain"
 
     simple_pie_proxy:

--- a/src/FeedBundle/Resources/views/FeedTest/index.html.twig
+++ b/src/FeedBundle/Resources/views/FeedTest/index.html.twig
@@ -15,7 +15,7 @@
                             <span class="prefix radius">{{ form_label(form.link) }}</span>
                         </div>
                         <div class="small-10 columns">
-                            {{ form_widget(form.link) }}
+                            {{ form_widget(form.link, { 'attr': {'autofocus': 'autofocus'} }) }}
                         </div>
                     </div>
                 </div>

--- a/tests/FeedBundle/Content/ExtractorTest.php
+++ b/tests/FeedBundle/Content/ExtractorTest.php
@@ -64,6 +64,14 @@ class ExtractorTest extends \PHPUnit_Framework_TestCase
             ->method('match')
             ->willReturn($defaultImprover);
 
+        $converterChain = $this->getMockBuilder('Api43\FeedBundle\Converter\ConverterChain')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $converterChain->expects($this->any())
+            ->method('convert')
+            ->will($this->returnArgument(0));
+
         $this->graby = $this->getMockBuilder('Graby\Graby')
             ->setMethods(['fetchContent'])
             ->disableOriginalConstructor()
@@ -79,7 +87,7 @@ class ExtractorTest extends \PHPUnit_Framework_TestCase
             ->method('getParser')
             ->willReturn($internalParser);
 
-        $contentExtractor = new Extractor($extractorChain, $improverChain, $parserChain);
+        $contentExtractor = new Extractor($extractorChain, $improverChain, $converterChain, $parserChain);
         $contentExtractor->init('internal', $feed, true);
 
         if (true === $customParser) {
@@ -158,7 +166,11 @@ class ExtractorTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $contentExtractor = new Extractor($extractorChain, $improverChain, new \Api43\FeedBundle\Parser\ParserChain());
+        $converterChain = $this->getMockBuilder('Api43\FeedBundle\Converter\ConverterChain')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $contentExtractor = new Extractor($extractorChain, $improverChain, $converterChain, new \Api43\FeedBundle\Parser\ParserChain());
         $contentExtractor->init('oops');
     }
 }

--- a/tests/FeedBundle/Content/ImportTest.php
+++ b/tests/FeedBundle/Content/ImportTest.php
@@ -4,6 +4,7 @@ namespace Tests\FeedBundle\Content;
 
 use Api43\FeedBundle\Content\Extractor;
 use Api43\FeedBundle\Content\Import;
+use Api43\FeedBundle\Converter\ConverterChain;
 use Api43\FeedBundle\Document\Feed;
 use Api43\FeedBundle\Extractor\ExtractorChain;
 use Api43\FeedBundle\Extractor\Youtube;
@@ -106,7 +107,7 @@ class ImportTest extends \PHPUnit_Framework_TestCase
         $parserChain = new ParserChain();
         $parserChain->addParser(new Internal(new Graby()), 'internal');
 
-        $extractor = new Extractor($extractorChain, $improverChain, $parserChain);
+        $extractor = new Extractor($extractorChain, $improverChain, new ConverterChain(), $parserChain);
 
         $feedRepo = $this->getMockBuilder('Api43\FeedBundle\Repository\FeedRepository')
             ->disableOriginalConstructor()
@@ -225,7 +226,7 @@ class ImportTest extends \PHPUnit_Framework_TestCase
         $parserChain = new ParserChain();
         $parserChain->addParser(new Internal(new Graby()), 'internal');
 
-        $extractor = new Extractor($extractorChain, $improverChain, $parserChain);
+        $extractor = new Extractor($extractorChain, $improverChain, new ConverterChain(), $parserChain);
 
         $feedRepo = $this->getMockBuilder('Api43\FeedBundle\Repository\FeedRepository')
             ->disableOriginalConstructor()

--- a/tests/FeedBundle/Converter/ConverterChainTest.php
+++ b/tests/FeedBundle/Converter/ConverterChainTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\FeedBundle\Converter;
+
+use Api43\FeedBundle\Converter\ConverterChain;
+
+class ConverterChainTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConvert()
+    {
+        $converter = $this->getMockBuilder('Api43\FeedBundle\Converter\AbstractConverter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $converter->expects($this->once())
+            ->method('convert')
+            ->will($this->returnValue('changed'));
+
+        $converterChain = new ConverterChain();
+        $converterChain->addConverter($converter, 'alias');
+
+        $this->assertEquals('changed', $converterChain->convert('url'));
+    }
+}

--- a/tests/FeedBundle/Converter/ConverterCompilerPassTest.php
+++ b/tests/FeedBundle/Converter/ConverterCompilerPassTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\FeedBundle\Converter;
+
+use Api43\FeedBundle\Converter\ConverterCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ConverterCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcessNoDefinition()
+    {
+        $container = new ContainerBuilder();
+        $res = $this->process($container);
+
+        $this->assertNull($res);
+    }
+
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('feed.converter.chain')
+            ->setPublic(false)
+        ;
+
+        $container
+            ->register('foo')
+            ->addTag('feed.converter', ['alias' => 'instagram'])
+        ;
+
+        $this->process($container);
+
+        $this->assertTrue($container->hasDefinition('feed.converter.chain'));
+
+        $definition = $container->getDefinition('feed.converter.chain');
+        $this->assertTrue($definition->hasMethodCall('addConverter'));
+
+        $calls = $definition->getMethodCalls();
+        $this->assertEquals('instagram', $calls[0][1][1]);
+    }
+
+    protected function process(ContainerBuilder $container)
+    {
+        $repeatedPass = new ConverterCompilerPass();
+        $repeatedPass->process($container);
+    }
+}

--- a/tests/FeedBundle/Converter/InstagramTest.php
+++ b/tests/FeedBundle/Converter/InstagramTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\FeedBundle\Converter;
+
+use Api43\FeedBundle\Converter\Instagram;
+use Psr\Log\NullLogger;
+
+class InstagramTest extends \PHPUnit_Framework_TestCase
+{
+    public function dataMatch()
+    {
+        return [
+            [
+                '<div></div>',
+                '<div></div>',
+                0,
+            ],
+            [
+                '<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-version="7" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:8px;"> <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:62.4537037037037% 0; text-align:center; width:100%;"> <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAMUExURczMzPf399fX1+bm5mzY9AMAAADiSURBVDjLvZXbEsMgCES5/P8/t9FuRVCRmU73JWlzosgSIIZURCjo/ad+EQJJB4Hv8BFt+IDpQoCx1wjOSBFhh2XssxEIYn3ulI/6MNReE07UIWJEv8UEOWDS88LY97kqyTliJKKtuYBbruAyVh5wOHiXmpi5we58Ek028czwyuQdLKPG1Bkb4NnM+VeAnfHqn1k4+GPT6uGQcvu2h2OVuIf/gWUFyy8OWEpdyZSa3aVCqpVoVvzZZ2VTnn2wU8qzVjDDetO90GSy9mVLqtgYSy231MxrY6I2gGqjrTY0L8fxCxfCBbhWrsYYAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div></div> <p style=" margin:8px 0 0 0; padding:0 4px;"> <a href="https://www.instagram.com/p/BQDVfhnlC2P/" style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;" target="_blank">Photo @ladzinski / It&#39;s good to feel small from time to time and stepping foot into the #GiantForest of #sequoianationalpark, you certainly do. Sequoia trees are among the oldest living trees on earth, some living in excess of 3,000 years old. You don&#39;t get this old without being resilient. Sequoias are a very thirsty tree so to speak, requiring a lot of water. In recent decades heat index has been slowly on the on the rise, coupled with the drought in California, is making life at lower elevations difficult for sequoia&#39;s. Some are showing signs of stress, shedding needles in an effort to fight the heat. Photographed #onassignment for @natgeo</a></p> <p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;">Une photo publiée par National Geographic (@natgeo) le <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2017-02-03T14:04:05+00:00">3 Févr. 2017 à 6h04 PST</time></p></div></blockquote> <script async defer src="//platform.instagram.com/en_US/embeds.js"></script>',
+                '<img src="https://scontent-cdg2-1.cdninstagram.com/t51.2885-15/e35/16464714_735605356614941_9152627590412894208_n.jpg" />',
+                1,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataMatch
+     */
+    public function testMatch($html, $expected, $instaExtractorOccurence)
+    {
+        $instaExtractor = $this->getMockBuilder('Api43\FeedBundle\Extractor\Instagram')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $instaExtractor->expects($this->exactly($instaExtractorOccurence))
+            ->method('match')
+            ->will($this->returnValue(true));
+
+        $instaExtractor->expects($this->exactly($instaExtractorOccurence))
+            ->method('getImageOnly')
+            ->will($this->returnValue('https://scontent-cdg2-1.cdninstagram.com/t51.2885-15/e35/16464714_735605356614941_9152627590412894208_n.jpg'));
+
+        $instaConverter = new Instagram($instaExtractor);
+        $instaConverter->setLogger(new NullLogger());
+        $this->assertContains($expected, $instaConverter->convert($html));
+    }
+
+    public function testMatchButInstaExtractFail()
+    {
+        $html = '<a href="https://www.instagram.com/p/BQDVfhnlC2P/" style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;" target="_blank">Photo</a>';
+
+        $instaExtractor = $this->getMockBuilder('Api43\FeedBundle\Extractor\Instagram')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $instaExtractor->expects($this->once())
+            ->method('match')
+            ->will($this->returnValue(true));
+
+        $instaExtractor->expects($this->once())
+            ->method('getImageOnly')
+            ->will($this->returnValue(''));
+
+        $instaConverter = new Instagram($instaExtractor);
+        $instaConverter->setLogger(new NullLogger());
+
+        $this->assertEquals($html, $instaConverter->convert($html));
+    }
+}


### PR DESCRIPTION
Add Converter. Yeah a new "notion".

Converter aim to convert some html into something else.
For example, an Instagram embed won't display the image but only a link to the instagram page. The Instagram converter will fetch the image and insert it in the html. So we'll have a preview of the image in the feed.

Might fix https://github.com/j0k3r/f43.me/issues/119

- [x] update README with Converters
- [x] add tests

Before:
![image](https://cloud.githubusercontent.com/assets/62333/22333722/cf527254-e3d7-11e6-9cb3-eafc5012bc53.png)

After:
![image](https://cloud.githubusercontent.com/assets/62333/22333734/db62fc1c-e3d7-11e6-9435-56961b6cd11b.png)
