### PR TITLE
Don’t duplicate Flickr photo

### DIFF
--- a/src/FeedBundle/Extractor/Flickr.php
+++ b/src/FeedBundle/Extractor/Flickr.php
@@ -55,12 +55,9 @@ class Flickr extends AbstractExtractor
             return '';
         }
 
-        $photo = isset($data['url']) ? $data['url'] : $data['thumbnail_url'];
-
         return '<div>' .
             '<h2>' . $data['title'] . '</h2>' . '
             <p>By <a href="' . $data['author_url'] . '">' . $data['author_name'] . '</a></p>' .
-            '<p><img src="' . $photo . '" /></p>' .
             $data['html'] .
             '</div>';
     }

--- a/tests/FeedBundle/Extractor/FlickrTest.php
+++ b/tests/FeedBundle/Extractor/FlickrTest.php
@@ -74,7 +74,7 @@ class FlickrTest extends \PHPUnit_Framework_TestCase
 
         // consecutive calls
         $content = $flickr->getContent();
-        $this->assertContains('<img src="https://0.0.0.0/large.jpg" />', $content);
+        $this->assertContains('<a data-flickr-embed="true"></a>', $content);
         $this->assertContains('<h2>title</h2>', $content);
         $this->assertContains('data-flickr-embed', $content);
         // this one will got an empty array
@@ -118,7 +118,7 @@ class FlickrTest extends \PHPUnit_Framework_TestCase
 
         // consecutive calls
         $content = $flickr->getContent();
-        $this->assertContains('<img src="https://0.0.0.0/small.jpg" />', $content);
+        $this->assertContains('<a data-flickr-embed="true"></a>', $content);
         $this->assertContains('<h2>title</h2>', $content);
         $this->assertContains('data-flickr-embed', $content);
         // this one will got an empty array


### PR DESCRIPTION
The HTML returned by Flickr already include the image tag, we don’t need to duplicate it.