### PR TITLE
Fix Reddit url when we append /.json

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1473,7 +1473,7 @@
                 "strip",
                 "tags"
             ],
-            "time": "2017-02-13 22:15:20"
+            "time": "2017-02-13T22:15:20+00:00"
         },
         {
             "name": "incenteev/composer-parameter-handler",
@@ -3228,16 +3228,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v3.3.10",
+            "version": "v3.3.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "cfef3b2d505ae4375b17032bd03ed9a3da4b7b43"
+                "reference": "97e753fa58c6ab8751e5f77995d1ed7737a99f1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/cfef3b2d505ae4375b17032bd03ed9a3da4b7b43",
-                "reference": "cfef3b2d505ae4375b17032bd03ed9a3da4b7b43",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/97e753fa58c6ab8751e5f77995d1ed7737a99f1b",
+                "reference": "97e753fa58c6ab8751e5f77995d1ed7737a99f1b",
                 "shasum": ""
             },
             "require": {
@@ -3260,7 +3260,7 @@
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
-                "phpdocumentor/type-resolver": "<0.2.0",
+                "phpdocumentor/type-resolver": "<0.2.1",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
             },
             "provide": {
@@ -3322,6 +3322,7 @@
             },
             "require-dev": {
                 "cache/integration-tests": "dev-master",
+                "doctrine/annotations": "~1.0",
                 "doctrine/cache": "~1.6",
                 "doctrine/data-fixtures": "1.0.*",
                 "doctrine/dbal": "~2.4",
@@ -3377,7 +3378,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2017-10-05T23:40:32+00:00"
+            "time": "2017-11-10T20:08:30+00:00"
         },
         {
             "name": "true/punycode",
@@ -4191,16 +4192,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v3.3.10",
+            "version": "v3.3.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "6e40d1c8bc4037edf3852c0b29fdd2923c4e2133"
+                "reference": "0cbc5e0f8af23dadf270371b9627f1f264cf6021"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/6e40d1c8bc4037edf3852c0b29fdd2923c4e2133",
-                "reference": "6e40d1c8bc4037edf3852c0b29fdd2923c4e2133",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/0cbc5e0f8af23dadf270371b9627f1f264cf6021",
+                "reference": "0cbc5e0f8af23dadf270371b9627f1f264cf6021",
                 "shasum": ""
             },
             "require": {
@@ -4249,7 +4250,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2017-10-02T06:54:00+00:00"
+            "time": "2017-11-07T14:16:22+00:00"
         },
         {
             "name": "symfony/polyfill-php72",

--- a/src/FeedBundle/Extractor/RedditPost.php
+++ b/src/FeedBundle/Extractor/RedditPost.php
@@ -24,8 +24,10 @@ class RedditPost extends AbstractExtractor
             return false;
         }
 
+        $url = 'https://' . $host . $path . '/.json';
+        $url = str_replace('//.json', '/.json', $url);
+
         try {
-            $url = str_replace('//.json', '/.json', $url . '/.json');
             $data = $this->client->get($url)->json();
         } catch (RequestException $e) {
             return false;
@@ -53,6 +55,6 @@ class RedditPost extends AbstractExtractor
 
         return '<div><h2>' . $this->redditPostData['title'] . '</h2>' .
             '<ul><li>Score: ' . $this->redditPostData['score'] . '</li><li>Comments: ' . $this->redditPostData['num_comments'] . '</li><li>Flair: ' . $this->redditPostData['link_flair_text'] . '</li><li>Author: ' . $this->redditPostData['author'] . '</li></ul>' .
-            '<p>' . $this->redditPostData['selftext'] . '</p></div>';
+            '</div>' . htmlspecialchars_decode($this->redditPostData['selftext_html']);
     }
 }

--- a/src/FeedBundle/Extractor/RedditVideo.php
+++ b/src/FeedBundle/Extractor/RedditVideo.php
@@ -24,8 +24,10 @@ class RedditVideo extends AbstractExtractor
             return false;
         }
 
+        $url = 'https://' . $host . $path . '/.json';
+        $url = str_replace('//.json', '/.json', $url);
+
         try {
-            $url = str_replace('//.json', '/.json', $url . '/.json');
             $data = $this->client->get($url)->json();
         } catch (RequestException $e) {
             return false;

--- a/tests/FeedBundle/Extractor/RedditPostTest.php
+++ b/tests/FeedBundle/Extractor/RedditPostTest.php
@@ -88,7 +88,7 @@ class RedditPostTest extends \PHPUnit_Framework_TestCase
                 'domain' => 'self.jailbreak',
                 'is_self' => true,
                 'title' => 'the title',
-                'selftext' => 'this is the text',
+                'selftext_html' => '&lt;div class="md"&gt;&lt;p&gt;test&lt;/p&gt;&lt;/div&gt;',
                 'score' => 100,
                 'author' => 'bob',
                 'num_comments' => 100,
@@ -117,6 +117,6 @@ class RedditPostTest extends \PHPUnit_Framework_TestCase
 
         $redditPost->match('https://www.reddit.com/r/jailbreak/comments/7bnvuq/request_tweak_that_allows_more_than_140/');
 
-        $this->assertSame('<div><h2>the title</h2><ul><li>Score: 100</li><li>Comments: 100</li><li>Flair: GIFS</li><li>Author: bob</li></ul><p>this is the text</p></div>', $redditPost->getContent());
+        $this->assertSame('<div><h2>the title</h2><ul><li>Score: 100</li><li>Comments: 100</li><li>Flair: GIFS</li><li>Author: bob</li></ul></div><div class="md"><p>test</p></div>', $redditPost->getContent());
     }
 }


### PR DESCRIPTION
Fix Guzzle parsing.

Url like `https://www.reddit.com/r/jailbreak/comments/7c0vil/comment/dpmbb97?st=J9TYQX9X&sh=1ac66372`
Will then be ready with `/.json` at the end which generate an error.

```
GuzzleHttp\Exception\ParseException: Unable to parse JSON data: JSON_ERROR_SYNTAX - Syntax error, malformed JSON
#11 vendor/guzzlehttp/guzzle/src/Message/Response.php(148): json
```