### PR TITLE
Catch all others exceptions

### DIFF
--- a/src/FeedBundle/Improver/DefaultImprover.php
+++ b/src/FeedBundle/Improver/DefaultImprover.php
@@ -79,6 +79,9 @@ class DefaultImprover
         } catch (RequestException $e) {
             // catch timeout, ssl verification that failed, etc ...
             return $url . (strpos($url, '?') ? '&' : '?') . 'not-changed';
+        } catch (\Exception $e) {
+            // in case anything else happend
+            return $url . (strpos($url, '?') ? '&' : '?') . 'oups';
         }
 
         $url = $response->getEffectiveUrl();

--- a/tests/FeedBundle/Improver/DefaultImproverTest.php
+++ b/tests/FeedBundle/Improver/DefaultImproverTest.php
@@ -58,4 +58,18 @@ class DefaultImproverTest extends TestCase
         $default = new DefaultImprover($client);
         $this->assertSame('http://0.0.0.0/content?not-changed', $default->updateUrl('http://0.0.0.0/content'));
     }
+
+    public function testUpdateUrlFailHard()
+    {
+        $client = new Client();
+
+        $mock = new Mock([
+            new Response(400, [], Stream::factory('oops')),
+        ]);
+
+        $client->getEmitter()->attach($mock);
+
+        $default = new DefaultImprover($client);
+        $this->assertSame('http:///floooh.github.io/2018/10/06/bombjack.html?oups', $default->updateUrl('http:///floooh.github.io/2018/10/06/bombjack.html'));
+    }
 }


### PR DESCRIPTION
In case the url is badly formatted, instead of killing the command, just catch the exception and jump to the next feed item

> [console] Error thrown while running command "feed:fetch-items --age=old". Message: "Unable to parse malformed url: http:///floooh.github.io/2018/10/06/bombjack.html"
