### PR TITLE
Do not try to improve url before graby

### DIFF
--- a/src/AppBundle/Improver/DefaultImprover.php
+++ b/src/AppBundle/Improver/DefaultImprover.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Improver;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
 
 /**
  * Default Improver.
@@ -67,24 +66,6 @@ class DefaultImprover
      */
     public function updateUrl($url)
     {
-        try {
-            $response = $this->client
-                ->get(
-                    $url,
-                    // force user agent for some provider (to avoid bad browser detection)
-                    ['headers' => [
-                        'User-Agent' => 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/15.0.874.92 Safari/535.2',
-                    ]]
-                );
-        } catch (RequestException $e) {
-            // catch timeout, ssl verification that failed, etc ...
-            return $url . (strpos($url, '?') ? '&' : '?') . 'not-changed';
-        } catch (\Exception $e) {
-            // in case anything else happend
-            return $url . (strpos($url, '?') ? '&' : '?') . 'oups';
-        }
-
-        $url = $response->getEffectiveUrl();
         // convert bad encoded character
         $url = str_replace('&amp%3B', '&', $url);
 

--- a/tests/AppBundle/Improver/DefaultImproverTest.php
+++ b/tests/AppBundle/Improver/DefaultImproverTest.php
@@ -5,7 +5,6 @@ namespace Tests\AppBundle\Improver;
 use AppBundle\Improver\DefaultImprover;
 use GuzzleHttp\Client;
 use GuzzleHttp\Message\Response;
-use GuzzleHttp\Stream\Stream;
 use GuzzleHttp\Subscriber\Mock;
 use PHPUnit\Framework\TestCase;
 
@@ -43,33 +42,5 @@ class DefaultImproverTest extends TestCase
         $default = new DefaultImprover($client);
         $this->assertSame($expected, $default->updateUrl($url));
         $this->assertSame('', $default->updateContent(''));
-    }
-
-    public function testUpdateUrlFail()
-    {
-        $client = new Client();
-
-        $mock = new Mock([
-            new Response(400, [], Stream::factory('oops')),
-        ]);
-
-        $client->getEmitter()->attach($mock);
-
-        $default = new DefaultImprover($client);
-        $this->assertSame('http://0.0.0.0/content?not-changed', $default->updateUrl('http://0.0.0.0/content'));
-    }
-
-    public function testUpdateUrlFailHard()
-    {
-        $client = new Client();
-
-        $mock = new Mock([
-            new Response(400, [], Stream::factory('oops')),
-        ]);
-
-        $client->getEmitter()->attach($mock);
-
-        $default = new DefaultImprover($client);
-        $this->assertSame('http:///floooh.github.io/2018/10/06/bombjack.html?oups', $default->updateUrl('http:///floooh.github.io/2018/10/06/bombjack.html'));
     }
 }


### PR DESCRIPTION
graby can now use some defined header from site_config to better parse website.
One of them is related to GDPR.
Using that update url feature, it’ll update the given url by the GDPR consent url. And then graby will parse that GDPR consent page instead of the real article.

As far as I remember that update url part was to get the latest url after some redirection and clean it.

Maybe that part should be moved elsewhere.