### PR TITLE
Update deps

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "alcaeus/mongo-php-adapter",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/alcaeus/mongo-php-adapter.git",
-                "reference": "4f21e1fdc21eee0e35bdaf854ecc3c58179d1ef7"
+                "reference": "6111fb94e2e67b24b19681715f9caee4309e1eb5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/alcaeus/mongo-php-adapter/zipball/4f21e1fdc21eee0e35bdaf854ecc3c58179d1ef7",
-                "reference": "4f21e1fdc21eee0e35bdaf854ecc3c58179d1ef7",
+                "url": "https://api.github.com/repos/alcaeus/mongo-php-adapter/zipball/6111fb94e2e67b24b19681715f9caee4309e1eb5",
+                "reference": "6111fb94e2e67b24b19681715f9caee4309e1eb5",
                 "shasum": ""
             },
             "require": {
@@ -69,7 +69,7 @@
                 "database",
                 "mongodb"
             ],
-            "time": "2018-03-05T20:40:55+00:00"
+            "time": "2019-02-08T07:16:38+00:00"
         },
         {
             "name": "behat/transliterator",
@@ -546,16 +546,16 @@
         },
         {
             "name": "doctrine/doctrine-bundle",
-            "version": "1.10.1",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineBundle.git",
-                "reference": "98551d71f515692c2278073e0d483763ac70b341"
+                "reference": "1f99e6645030542079c57d4680601a4a8778a1bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/98551d71f515692c2278073e0d483763ac70b341",
-                "reference": "98551d71f515692c2278073e0d483763ac70b341",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/1f99e6645030542079c57d4680601a4a8778a1bd",
+                "reference": "1f99e6645030542079c57d4680601a4a8778a1bd",
                 "shasum": ""
             },
             "require": {
@@ -627,7 +627,7 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2019-01-07T15:31:08+00:00"
+            "time": "2019-02-06T13:18:04+00:00"
         },
         {
             "name": "doctrine/doctrine-cache-bundle",
@@ -1805,16 +1805,16 @@
         },
         {
             "name": "j0k3r/graby",
-            "version": "1.19.0",
+            "version": "1.19.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/j0k3r/graby.git",
-                "reference": "c9e85d2363c91642ff35f198cff1817be8e193e1"
+                "reference": "6c1506f19d1bb876fb26bfc11e3e11a993eb7fe8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/j0k3r/graby/zipball/c9e85d2363c91642ff35f198cff1817be8e193e1",
-                "reference": "c9e85d2363c91642ff35f198cff1817be8e193e1",
+                "url": "https://api.github.com/repos/j0k3r/graby/zipball/6c1506f19d1bb876fb26bfc11e3e11a993eb7fe8",
+                "reference": "6c1506f19d1bb876fb26bfc11e3e11a993eb7fe8",
                 "shasum": ""
             },
             "require": {
@@ -1860,20 +1860,20 @@
                 }
             ],
             "description": "Graby helps you extract article content from web pages",
-            "time": "2019-01-22T15:39:28+00:00"
+            "time": "2019-02-13T10:04:47+00:00"
         },
         {
             "name": "j0k3r/graby-site-config",
-            "version": "1.0.73",
+            "version": "1.0.75",
             "source": {
                 "type": "git",
                 "url": "https://github.com/j0k3r/graby-site-config.git",
-                "reference": "350d0c3f1333203af0985d9243d457cf9e4479cd"
+                "reference": "099f86b9c78c015995025658cc1bee28880a8243"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/j0k3r/graby-site-config/zipball/350d0c3f1333203af0985d9243d457cf9e4479cd",
-                "reference": "350d0c3f1333203af0985d9243d457cf9e4479cd",
+                "url": "https://api.github.com/repos/j0k3r/graby-site-config/zipball/099f86b9c78c015995025658cc1bee28880a8243",
+                "reference": "099f86b9c78c015995025658cc1bee28880a8243",
                 "shasum": ""
             },
             "require": {
@@ -1900,7 +1900,7 @@
                 }
             ],
             "description": "Graby site config files",
-            "time": "2019-01-21T15:50:12+00:00"
+            "time": "2019-02-25T10:26:08+00:00"
         },
         {
             "name": "j0k3r/php-imgur-api-client",
@@ -1964,16 +1964,16 @@
         },
         {
             "name": "j0k3r/php-readability",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/j0k3r/php-readability.git",
-                "reference": "6a0f3337a65a66d6aa78f55e47d70d98b6a3bec6"
+                "reference": "3c0289bf8943cbef6a2cc89b645c33617fd38066"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/j0k3r/php-readability/zipball/6a0f3337a65a66d6aa78f55e47d70d98b6a3bec6",
-                "reference": "6a0f3337a65a66d6aa78f55e47d70d98b6a3bec6",
+                "url": "https://api.github.com/repos/j0k3r/php-readability/zipball/3c0289bf8943cbef6a2cc89b645c33617fd38066",
+                "reference": "3c0289bf8943cbef6a2cc89b645c33617fd38066",
                 "shasum": ""
             },
             "require": {
@@ -2034,7 +2034,7 @@
                 "extraction",
                 "html"
             ],
-            "time": "2019-02-04T10:29:55+00:00"
+            "time": "2019-02-07T15:08:33+00:00"
         },
         {
             "name": "j0k3r/safecurl",
@@ -2386,16 +2386,16 @@
         },
         {
             "name": "ocramius/package-versions",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "4489d5002c49d55576fa0ba786f42dbb009be46f"
+                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/4489d5002c49d55576fa0ba786f42dbb009be46f",
-                "reference": "4489d5002c49d55576fa0ba786f42dbb009be46f",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
+                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
                 "shasum": ""
             },
             "require": {
@@ -2404,6 +2404,7 @@
             },
             "require-dev": {
                 "composer/composer": "^1.6.3",
+                "doctrine/coding-standard": "^5.0.1",
                 "ext-zip": "*",
                 "infection/infection": "^0.7.1",
                 "phpunit/phpunit": "^7.0.0"
@@ -2431,7 +2432,7 @@
                 }
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2018-02-05T13:05:30+00:00"
+            "time": "2019-02-21T12:16:21+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -4392,16 +4393,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.14.0",
+            "version": "v2.14.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2"
+                "reference": "ff401e58261ffc5934a58f795b3f95b355e276cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/b788ea0af899cedc8114dca7db119c93b6685da2",
-                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/ff401e58261ffc5934a58f795b3f95b355e276cb",
+                "reference": "ff401e58261ffc5934a58f795b3f95b355e276cb",
                 "shasum": ""
             },
             "require": {
@@ -4421,9 +4422,6 @@
                 "symfony/polyfill-php72": "^1.4",
                 "symfony/process": "^3.0 || ^4.0",
                 "symfony/stopwatch": "^3.0 || ^4.0"
-            },
-            "conflict": {
-                "hhvm": "*"
             },
             "require-dev": {
                 "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
@@ -4448,11 +4446,6 @@
                 "php-cs-fixer"
             ],
             "type": "application",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.14-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
@@ -4484,7 +4477,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2019-01-04T18:29:47+00:00"
+            "time": "2019-02-17T17:44:13+00:00"
         },
         {
             "name": "guzzle/guzzle",

--- a/src/AppBundle/Parser/ParserChain.php
+++ b/src/AppBundle/Parser/ParserChain.php
@@ -31,7 +31,7 @@ class ParserChain
      */
     public function getParser($alias)
     {
-        if (array_key_exists($alias, $this->parsers)) {
+        if (\array_key_exists($alias, $this->parsers)) {
             return $this->parsers[$alias];
         }
 


### PR DESCRIPTION
Changelogs summary:

 - ocramius/package-versions updated from 1.3.0 to 1.4.0
   See changes: https://github.com/Ocramius/PackageVersions/compare/1.3.0...1.4.0
   Release notes: https://github.com/Ocramius/PackageVersions/releases/tag/1.4.0

 - doctrine/doctrine-bundle updated from 1.10.1 to 1.10.2
   See changes: https://github.com/doctrine/DoctrineBundle/compare/1.10.1...1.10.2
   Release notes: https://github.com/doctrine/DoctrineBundle/releases/tag/1.10.2

 - j0k3r/graby-site-config updated from 1.0.73 to 1.0.75
   See changes: https://github.com/j0k3r/graby-site-config/compare/1.0.73...1.0.75
   Release notes: https://github.com/j0k3r/graby-site-config/releases/tag/1.0.75

 - j0k3r/php-readability updated from 1.2.0 to 1.2.1
   See changes: https://github.com/j0k3r/php-readability/compare/1.2.0...1.2.1
   Release notes: https://github.com/j0k3r/php-readability/releases/tag/1.2.1

 - j0k3r/graby updated from 1.19.0 to 1.19.1
   See changes: https://github.com/j0k3r/graby/compare/1.19.0...1.19.1
   Release notes: https://github.com/j0k3r/graby/releases/tag/1.19.1

 - alcaeus/mongo-php-adapter updated from 1.1.5 to 1.1.6
   See changes: https://github.com/alcaeus/mongo-php-adapter/compare/1.1.5...1.1.6
   Release notes: https://github.com/alcaeus/mongo-php-adapter/releases/tag/1.1.6

 - friendsofphp/php-cs-fixer updated from v2.14.0 to v2.14.2
   See changes: https://github.com/FriendsOfPHP/PHP-CS-Fixer/compare/v2.14.0...v2.14.2
   Release notes: https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/tag/v2.14.2