### PR TITLE
Be sure to catch all exceptions

### DIFF
--- a/src/AppBundle/Extractor/Github.php
+++ b/src/AppBundle/Extractor/Github.php
@@ -2,8 +2,6 @@
 
 namespace AppBundle\Extractor;
 
-use Http\Client\Exception\RequestException;
-
 class Github extends AbstractExtractor
 {
     protected $githubClientId;
@@ -159,7 +157,7 @@ class Github extends AbstractExtractor
                     ]
                 )
                 ->getBody();
-        } catch (RequestException $e) {
+        } catch (\Exception $e) {
             // Github will return a 404 if no readme are found
             return '';
         }

--- a/src/AppBundle/Extractor/Tumblr.php
+++ b/src/AppBundle/Extractor/Tumblr.php
@@ -2,8 +2,6 @@
 
 namespace AppBundle\Extractor;
 
-use Http\Client\Exception\RequestException;
-
 class Tumblr extends AbstractExtractor
 {
     protected $tumblrApiKey;
@@ -42,7 +40,7 @@ class Tumblr extends AbstractExtractor
             $tumblrUser = $this->client
                 ->get($url)
                 ->getHeaderLine('X-Tumblr-User');
-        } catch (RequestException $e) {
+        } catch (\Exception $e) {
             $this->logger->warning('Tumblr extract failed for: ' . $url, [
                 'exception' => $e,
             ]);


### PR DESCRIPTION
RequestException does’t catch 404 error.
Switching to \Exception to catch everything.