### PR TITLE
Use RabbitMQ to consume new items

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -19,6 +19,7 @@ class AppKernel extends Kernel
             new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new Sentry\SentryBundle\SentryBundle(),
             new Http\HttplugBundle\HttplugBundle(),
+            new Swarrot\SwarrotBundle\SwarrotBundle(),
             new AppBundle\AppBundle(),
         ];
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -105,3 +105,30 @@ httplug:
                         'User-Agent': f43.me/1.0
     discovery:
         client: false
+
+swarrot:
+    provider: amqp_lib # pecl or amqp_lib
+    connections:
+        rabbitmq:
+            host: '%rabbitmq_host%'
+            port: '%rabbitmq_port%'
+            login: '%rabbitmq_login%'
+            password: '%rabbitmq_password%'
+            vhost: '/'
+    consumers:
+        f43.fetch_items:
+            processor: AppBundle\Consumer\FetchItems
+            extras:
+                poll_interval: 500000
+            middleware_stack:
+                - configurator: swarrot.processor.max_messages
+                  extras:
+                      max_messages: 20
+                - configurator: swarrot.processor.doctrine_connection
+                - configurator: swarrot.processor.retry
+                - configurator: swarrot.processor.exception_catcher
+                - configurator: swarrot.processor.ack
+    messages_types:
+        f43.fetch_items.publisher:
+            connection: rabbitmq
+            exchange: f43.fetch_items

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -33,3 +33,6 @@ doctrine:
         user: "root"
         password: ~
         charset: utf8mb4
+
+parameters:
+    swarrot.publisher.class: Swarrot\SwarrotBundle\Broker\BlackholePublisher

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -56,3 +56,9 @@ parameters:
     github.client_secret: xxx
 
     sentry_dsn: "https://xxx:xxx@sentry.io/666"
+
+    # rabbit
+    rabbitmq_host: 127.0.0.1
+    rabbitmq_port: 5672
+    rabbitmq_login: guest
+    rabbitmq_password: guest

--- a/app/config/parameters.yml.docker
+++ b/app/config/parameters.yml.docker
@@ -36,3 +36,7 @@ parameters:
     github.client_id: xxx
     github.client_secret: xxx
     sentry_dsn: "https://xxx:xxx@sentry.io/666"
+    rabbitmq_host: 127.0.0.1
+    rabbitmq_port: 5672
+    rabbitmq_login: guest
+    rabbitmq_password: guest

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -36,3 +36,7 @@ parameters:
     github.client_id: xxx
     github.client_secret: xxx
     sentry_dsn:
+    rabbitmq_host: 127.0.0.1
+    rabbitmq_port: 5672
+    rabbitmq_login: guest
+    rabbitmq_password: guest

--- a/app/config/rabbit_vhost.yml
+++ b/app/config/rabbit_vhost.yml
@@ -1,0 +1,17 @@
+'/':
+    parameters:
+        # If true, all queues will have a dl and the corresponding mapping with the exchange "dl"
+        with_dl: false
+        # If true, all exchange will be declared with an unroutable config
+        with_unroutable: false
+
+    exchanges:
+        f43.fetch_items:
+            type: direct
+            durable: true
+
+    queues:
+        f43.fetch_items:
+            durable: true
+            bindings:
+                - exchange: f43.fetch_items

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -33,6 +33,10 @@ services:
         tags:
             - { name: kernel.event_listener, event: app.after_item_cached, method: pingHub }
 
+    AppBundle\EventListener\FeedSubscriber:
+        tags:
+            - { name: kernel.event_listener, event: app.after_feed_creation, method: sync }
+
     AppBundle\Xml\SimplePieProxy:
         arguments:
             $cache: "%kernel.root_dir%/cache/simplepie/"

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -23,6 +23,10 @@ services:
         arguments:
             $domain: "%domain%"
 
+    AppBundle\Consumer\FetchItems:
+        arguments:
+            $domain: "%domain%"
+
     AppBundle\EventListener\ItemSubscriber:
         arguments:
             $hub: "http://pubsubhubbub.appspot.com"
@@ -84,3 +88,7 @@ services:
 
 
     Http\Client\Common\HttpMethodsClientInterface: '@httplug.client.default.http_methods'
+
+    # alias to service from their class name
+    Swarrot\SwarrotBundle\Broker\Publisher:
+        alias: swarrot.publisher

--- a/composer.json
+++ b/composer.json
@@ -28,26 +28,29 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/symfony": "3.4.*",
+        "beberlei/doctrineextensions": "^1.2",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-migrations-bundle": "^2.0",
         "doctrine/orm": "^2.5",
-        "twig/extensions": "~1.1",
-        "symfony/monolog-bundle": "^3.1.0",
-        "sensio/distribution-bundle": "^5.0.19",
-        "sensio/framework-extra-bundle": "^5.2.1",
         "incenteev/composer-parameter-handler": "^2.0",
-        "stof/doctrine-extensions-bundle": "~1.1",
         "j0k3r/graby": "^2.0",
-        "simplepie/simplepie": "~1.4",
-        "zurb/foundation": "4.3.2",
         "j0k3r/php-imgur-api-client": "~3.0",
         "mnsami/composer-custom-directory-installer": "~1.0",
-        "ricardoper/twitteroauth": "~1.0",
-        "sentry/sentry-symfony": "^3.0",
+        "odolbeau/rabbit-mq-admin-toolkit": "^4.0",
+        "php-amqplib/php-amqplib": "^2.10",
         "php-http/guzzle6-adapter": "^2.0",
         "php-http/httplug-bundle": "^1.14",
-        "beberlei/doctrineextensions": "^1.2"
+        "ricardoper/twitteroauth": "~1.0",
+        "sensio/distribution-bundle": "^5.0.19",
+        "sensio/framework-extra-bundle": "^5.2.1",
+        "sentry/sentry-symfony": "^3.0",
+        "simplepie/simplepie": "~1.4",
+        "stof/doctrine-extensions-bundle": "~1.1",
+        "swarrot/swarrot-bundle": "^1.6",
+        "symfony/monolog-bundle": "^3.1.0",
+        "symfony/symfony": "3.4.*",
+        "twig/extensions": "~1.1",
+        "zurb/foundation": "4.3.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.0",
@@ -80,7 +83,8 @@
         "platform": {
             "php": "7.1"
         },
-        "bin-dir": "bin"
+        "bin-dir": "bin",
+        "sort-packages": true
     },
     "extra": {
         "symfony-app-dir": "app",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d33bf3c457868e624d387d560c14ad97",
+    "content-hash": "6f4deda261a5ae3724b16ff62124f717",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -1439,13 +1439,13 @@
             "authors": [
                 {
                     "name": "Multiple users",
-                    "role": "Original developers",
-                    "homepage": "https://code.google.com/p/html5lib/"
+                    "homepage": "https://code.google.com/p/html5lib/",
+                    "role": "Original developers"
                 },
                 {
                     "name": "Sébastien Lavoie",
-                    "role": "Packager",
-                    "homepage": "http://blog.lavoie.sl"
+                    "homepage": "http://blog.lavoie.sl",
+                    "role": "Packager"
                 },
                 {
                     "name": "didier Belot",
@@ -2220,25 +2220,25 @@
             "authors": [
                 {
                     "name": "Keyvan Minoukadeh",
-                    "role": "Developer (ported original JS code to PHP)",
                     "email": "keyvan@keyvan.net",
-                    "homepage": "http://keyvan.net"
+                    "homepage": "http://keyvan.net",
+                    "role": "Developer (ported original JS code to PHP)"
                 },
                 {
                     "name": "Arc90",
-                    "role": "Developer (original JS version)",
-                    "homepage": "http://arc90.com"
+                    "homepage": "http://arc90.com",
+                    "role": "Developer (original JS version)"
                 },
                 {
                     "name": "Jeremy Benoist",
-                    "role": "Developer",
                     "email": "jeremy.benoist@gmail.com",
-                    "homepage": "http://www.j0k3r.net"
+                    "homepage": "http://www.j0k3r.net",
+                    "role": "Developer"
                 },
                 {
                     "name": "DitherSky",
-                    "role": "Developer (https://github.com/Dither/full-text-rss)",
-                    "homepage": "https://github.com/Dither"
+                    "homepage": "https://github.com/Dither",
+                    "role": "Developer (https://github.com/Dither/full-text-rss)"
                 }
             ],
             "description": "Automatic article extraction from HTML",
@@ -2603,6 +2603,56 @@
             "time": "2017-05-04T11:12:50+00:00"
         },
         {
+            "name": "odolbeau/rabbit-mq-admin-toolkit",
+            "version": "v4.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/odolbeau/rabbit-mq-admin-toolkit.git",
+                "reference": "19f9962ce9267ae088132dbcccbdc4607d0872cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/odolbeau/rabbit-mq-admin-toolkit/zipball/19f9962ce9267ae088132dbcccbdc4607d0872cb",
+                "reference": "19f9962ce9267ae088132dbcccbdc4607d0872cb",
+                "shasum": ""
+            },
+            "require": {
+                "swarrot/swarrot": "~2.0|~3.0",
+                "symfony/console": "^2.7|^3.0|^4.0",
+                "symfony/yaml": "^2.4|^3.0|^4.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~1.12",
+                "phpunit/phpunit": "^5.7"
+            },
+            "bin": [
+                "rabbit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Bab\\RabbitMq": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "RabbitMQ administration toolkit",
+            "keywords": [
+                "AMQP",
+                "admin",
+                "rabbitmq",
+                "toolkit"
+            ],
+            "time": "2017-12-27T10:48:40+00:00"
+        },
+        {
             "name": "paragonie/random_compat",
             "version": "v9.99.99",
             "source": {
@@ -2646,6 +2696,80 @@
                 "random"
             ],
             "time": "2018-07-02T15:55:56+00:00"
+        },
+        {
+            "name": "php-amqplib/php-amqplib",
+            "version": "v2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-amqplib/php-amqplib.git",
+                "reference": "04e5366f032906d5f716890427e425e71307d3a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-amqplib/php-amqplib/zipball/04e5366f032906d5f716890427e425e71307d3a8",
+                "reference": "04e5366f032906d5f716890427e425e71307d3a8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bcmath": "*",
+                "ext-sockets": "*",
+                "php": ">=5.6"
+            },
+            "replace": {
+                "videlalvaro/php-amqplib": "self.version"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "nategood/httpful": "^0.2.20",
+                "phpdocumentor/phpdocumentor": "dev-master",
+                "phpunit/phpunit": "^5.7|^6.5|^7.0",
+                "squizlabs/php_codesniffer": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpAmqpLib\\": "PhpAmqpLib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alvaro Videla",
+                    "role": "Original Maintainer"
+                },
+                {
+                    "name": "John Kelly",
+                    "role": "Maintainer",
+                    "email": "johnmkelly86@gmail.com"
+                },
+                {
+                    "name": "Raúl Araya",
+                    "role": "Maintainer",
+                    "email": "nubeiro@gmail.com"
+                },
+                {
+                    "name": "Luke Bakken",
+                    "role": "Maintainer",
+                    "email": "luke@bakken.io"
+                }
+            ],
+            "description": "Formerly videlalvaro/php-amqplib.  This library is a pure PHP implementation of the AMQP protocol. It's been tested against RabbitMQ.",
+            "homepage": "https://github.com/php-amqplib/php-amqplib/",
+            "keywords": [
+                "message",
+                "queue",
+                "rabbitmq"
+            ],
+            "time": "2019-08-08T18:28:18+00:00"
         },
         {
             "name": "php-http/client-common",
@@ -4105,16 +4229,16 @@
         },
         {
             "name": "sentry/sentry",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-php.git",
-                "reference": "8e27e6c5fcf6f01fc2e5235dd14cc0b2b347d793"
+                "reference": "646f6ada8b89a08063e31f54ed6d260bd6879239"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/8e27e6c5fcf6f01fc2e5235dd14cc0b2b347d793",
-                "reference": "8e27e6c5fcf6f01fc2e5235dd14cc0b2b347d793",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/646f6ada8b89a08063e31f54ed6d260bd6879239",
+                "reference": "646f6ada8b89a08063e31f54ed6d260bd6879239",
                 "shasum": ""
             },
             "require": {
@@ -4143,12 +4267,12 @@
                 "phpstan/phpstan": "^0.10.3",
                 "phpstan/phpstan-phpunit": "^0.10",
                 "phpunit/phpunit": "^7.0",
-                "symfony/phpunit-bridge": "^4.1.6"
+                "symfony/phpunit-bridge": "^4.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -4180,7 +4304,7 @@
                 "logging",
                 "sentry"
             ],
-            "time": "2019-06-13T11:27:23+00:00"
+            "time": "2019-08-22T07:37:30+00:00"
         },
         {
             "name": "sentry/sentry-symfony",
@@ -4435,6 +4559,143 @@
                 "tree"
             ],
             "time": "2017-12-24T16:06:50+00:00"
+        },
+        {
+            "name": "swarrot/swarrot",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swarrot/swarrot.git",
+                "reference": "698fb79bd8904e5da244ac33312ad14e517bac97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swarrot/swarrot/zipball/698fb79bd8904e5da244ac33312ad14e517bac97",
+                "reference": "698fb79bd8904e5da244ac33312ad14e517bac97",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "psr/log": "^1.0",
+                "symfony/options-resolver": "^3.4 || ^4.1"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.8",
+                "doctrine/common": "^2.3",
+                "doctrine/dbal": "^2.2",
+                "php-amqplib/php-amqplib": "^2.1",
+                "php-http/curl-client": "^2.0",
+                "phpunit/phpunit": "^7.5",
+                "queue-interop/amqp-interop": "^0.5",
+                "queue-interop/queue-interop": "^0.5",
+                "sentry/sentry": "^1.5",
+                "stomp-php/stomp-php": "^4.3.1"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "^2.8",
+                "pecl-amqp": "*",
+                "php-amqplib/php-amqplib": "^2.1",
+                "queue-interop/amqp-interop": "^0.5",
+                "queue-interop/queue-interop": "^0.5",
+                "sentry/sentry": "^1.5",
+                "stomp-php/stomp-php": "^4.3.1",
+                "symfony/console": "^3.4 || ^4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Swarrot\\": "src/Swarrot"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Olivier Dolbeau",
+                    "homepage": "http://odolbeau.fr/"
+                }
+            ],
+            "description": "A simple lib to consume RabbitMQ queues",
+            "keywords": [
+                "AMQP",
+                "queue",
+                "swarrot",
+                "worker"
+            ],
+            "time": "2019-05-19T15:13:16+00:00"
+        },
+        {
+            "name": "swarrot/swarrot-bundle",
+            "version": "v1.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swarrot/SwarrotBundle.git",
+                "reference": "f3e5b8f83b38121262d29adf908e4bccae6d85ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swarrot/SwarrotBundle/zipball/f3e5b8f83b38121262d29adf908e4bccae6d85ea",
+                "reference": "f3e5b8f83b38121262d29adf908e4bccae6d85ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "psr/log": "^1.0",
+                "swarrot/swarrot": "^3.4",
+                "symfony/config": "^3.4|^4.1",
+                "symfony/console": "^3.4|^4.1",
+                "symfony/dependency-injection": "^3.4|^4.1",
+                "symfony/http-kernel": "^3.4|^4.1",
+                "symfony/yaml": "^3.4|^4.1"
+            },
+            "require-dev": {
+                "doctrine/common": "^2.2",
+                "doctrine/dbal": "^2.2",
+                "php-amqplib/php-amqplib": "^2.9",
+                "phpunit/phpunit": "^7.5",
+                "sentry/sentry-symfony": "^2.3",
+                "symfony/phpunit-bridge": "^4.0"
+            },
+            "suggest": {
+                "php-amqplib/php-amqplib": "Required if using amqp_lib"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Swarrot\\SwarrotBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Olivier Dolbeau",
+                    "homepage": "http://odolbeau.fr/"
+                }
+            ],
+            "description": "SwarrotBundle",
+            "keywords": [
+                "bundle",
+                "swarrot"
+            ],
+            "time": "2019-07-28T22:03:26+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -5269,14 +5530,14 @@
             "authors": [
                 {
                     "name": "Nicola Asuni",
-                    "role": "Main developer",
                     "email": "info@tecnick.com",
-                    "homepage": "http://nicolaasuni.tecnick.com"
+                    "homepage": "http://nicolaasuni.tecnick.com",
+                    "role": "Main developer"
                 },
                 {
                     "name": "wallabag/core",
-                    "role": "Developers",
-                    "homepage": "https://www.wallabag.org"
+                    "homepage": "https://www.wallabag.org",
+                    "role": "Developers"
                 }
             ],
             "description": "Keeping a working 6.2.x TCPDF version.",
@@ -6420,9 +6681,9 @@
             "authors": [
                 {
                     "name": "Kitamura Satoshi",
-                    "role": "Original creator",
                     "email": "with.no.parachute@gmail.com",
-                    "homepage": "https://www.facebook.com/satooshi.jp"
+                    "homepage": "https://www.facebook.com/satooshi.jp",
+                    "role": "Original creator"
                 },
                 {
                     "name": "Takashi Matsuo",

--- a/data/supervisor.conf
+++ b/data/supervisor.conf
@@ -1,0 +1,32 @@
+[group:fetch_items]
+programs=fetch_items_1,fetch_items_2,fetch_items_3
+
+[program:fetch_items_1]
+directory=/path/to/f43
+command=/usr/bin/php bin/console swarrot:consume:f43.fetch_items --env=prod f43.fetch_items
+autostart=true
+autorestart=true
+stderr_logfile=/space/logs/supervisord/fetch_items_1.err
+stdout_logfile=/space/logs/supervisord/fetch_items_1.log
+user=deploy
+environment = http_proxy="",https_proxy=""
+
+[program:fetch_items_2]
+directory=/path/to/f43
+command=/usr/bin/php bin/console swarrot:consume:f43.fetch_items --env=prod f43.fetch_items
+autostart=true
+autorestart=true
+stderr_logfile=/space/logs/supervisord/fetch_items_2.err
+stdout_logfile=/space/logs/supervisord/fetch_items_2.log
+user=deploy
+environment = http_proxy="",https_proxy=""
+
+[program:fetch_items_3]
+directory=/path/to/f43
+command=/usr/bin/php bin/console swarrot:consume:f43.fetch_items --env=prod f43.fetch_items
+autostart=true
+autorestart=true
+stderr_logfile=/space/logs/supervisord/fetch_items_3.err
+stdout_logfile=/space/logs/supervisord/fetch_items_3.log
+user=deploy
+environment = http_proxy="",https_proxy=""

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -35,6 +35,6 @@
     </filter>
 
     <!-- <logging>
-        <log type="coverage-html" target="build/coverage" title="FullText" charset="UTF-8" yui="true" highlight="true" lowUpperBound="35" highLowerBound="70"/>
+        <log type="coverage-html" target="build/coverage" lowUpperBound="35" highLowerBound="70"/>
     </logging> -->
 </phpunit>

--- a/src/AppBundle/AppEvents.php
+++ b/src/AppBundle/AppEvents.php
@@ -5,4 +5,5 @@ namespace AppBundle;
 final class AppEvents
 {
     const AFTER_ITEM_CACHED = 'app.after_item_cached';
+    const AFTER_FEED_CREATION = 'app.after_feed_creation';
 }

--- a/src/AppBundle/Consumer/FetchItems.php
+++ b/src/AppBundle/Consumer/FetchItems.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace AppBundle\Consumer;
+
+use AppBundle\Content\Import;
+use AppBundle\Repository\FeedRepository;
+use Psr\Log\LoggerInterface;
+use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Consumer message to fetch new items for a given feed.
+ */
+class FetchItems implements ProcessorInterface
+{
+    private $doctrine;
+    private $feedRepository;
+    private $contentImport;
+    private $router;
+    private $domain;
+    private $logger;
+
+    public function __construct(RegistryInterface $doctrine, FeedRepository $feedRepository, Import $contentImport, RouterInterface $router, LoggerInterface $logger, $domain)
+    {
+        $this->doctrine = $doctrine;
+        $this->feedRepository = $feedRepository;
+        $this->contentImport = $contentImport;
+        $this->router = $router;
+        $this->domain = $domain;
+        $this->logger = $logger;
+    }
+
+    public function process(Message $message, array $options)
+    {
+        $data = json_decode($message->getBody(), true);
+
+        /** @var \AppBundle\Entity\Feed|null */
+        $feed = $this->feedRepository->find($data['feed_id']);
+
+        if (null === $feed) {
+            $this->logger->error('Can not find feed', ['feed' => $data['feed_id']]);
+
+            return false;
+        }
+
+        $this->logger->notice('Consume f43.feed_new message', ['feed' => $feed->getSlug()]);
+
+        // define host for generating route
+        $context = $this->router->getContext();
+        $context->setHost($this->domain);
+
+        $em = $this->doctrine->getEntityManager();
+
+        // in case of the manager is closed following a previous exception
+        if (!$em->isOpen()) {
+            $em = $this->doctrine->resetEntityManager();
+
+            $this->contentImport->setEntityManager($em);
+        }
+
+        $totalCached = $this->contentImport->process([$feed]);
+
+        $this->logger->notice('<comment>' . $totalCached . '</comment> items cached for <info>' . $feed->getSlug() . '</info>');
+
+        return true;
+    }
+}

--- a/src/AppBundle/Content/Import.php
+++ b/src/AppBundle/Content/Import.php
@@ -6,7 +6,7 @@ use AppBundle\AppEvents;
 use AppBundle\Entity\Feed;
 use AppBundle\Entity\Item;
 use AppBundle\Entity\Log;
-use AppBundle\Event\ItemEvent;
+use AppBundle\Event\ItemsCachedEvent;
 use AppBundle\Repository\FeedRepository;
 use AppBundle\Repository\ItemRepository;
 use AppBundle\Xml\SimplePieProxy;
@@ -150,7 +150,7 @@ class Import
             $this->logger->debug('<info>Ping hubs...</info>');
 
             // send an event about new feed updated
-            $event = new ItemEvent($feedUpdated);
+            $event = new ItemsCachedEvent($feedUpdated);
 
             $this->eventDispatcher->dispatch(
                 AppEvents::AFTER_ITEM_CACHED,

--- a/src/AppBundle/Content/Import.php
+++ b/src/AppBundle/Content/Import.php
@@ -35,6 +35,11 @@ class Import
         $this->logger = $logger;
     }
 
+    public function setEntityManager(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+    }
+
     /**
      * Process feeds in parameter:
      *     - fetch xml feed

--- a/src/AppBundle/Entity/Feed.php
+++ b/src/AppBundle/Entity/Feed.php
@@ -125,6 +125,20 @@ class Feed
     }
 
     /**
+     * Set id.
+     *
+     * @param int $id
+     *
+     * @return self
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
      * Get id.
      *
      * @return int $id

--- a/src/AppBundle/Event/ItemsCachedEvent.php
+++ b/src/AppBundle/Event/ItemsCachedEvent.php
@@ -4,7 +4,7 @@ namespace AppBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
 
-class ItemEvent extends Event
+class ItemsCachedEvent extends Event
 {
     /**
      * Feeds slug.

--- a/src/AppBundle/Event/NewFeedEvent.php
+++ b/src/AppBundle/Event/NewFeedEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace AppBundle\Event;
+
+use AppBundle\Entity\Feed;
+use Symfony\Component\EventDispatcher\Event;
+
+class NewFeedEvent extends Event
+{
+    /**
+     * Feed entity.
+     *
+     * @var Feed
+     */
+    protected $feed;
+
+    /**
+     * Store slug feed that need to be dispatched.
+     *
+     * @param Feed $feed
+     */
+    public function __construct(Feed $feed)
+    {
+        $this->feed = $feed;
+    }
+
+    public function getFeed()
+    {
+        return $this->feed;
+    }
+}

--- a/src/AppBundle/EventListener/FeedSubscriber.php
+++ b/src/AppBundle/EventListener/FeedSubscriber.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace AppBundle\EventListener;
+
+use AppBundle\Event\NewFeedEvent;
+use PhpAmqpLib\Exception\AMQPExceptionInterface;
+use Swarrot\Broker\Message;
+use Swarrot\SwarrotBundle\Broker\Publisher;
+
+class FeedSubscriber
+{
+    protected $publisher;
+
+    /**
+     * Create a new subscriber.
+     *
+     * @param Publisher $publisher Used to push a message to RabbitMQ
+     */
+    public function __construct(Publisher $publisher)
+    {
+        $this->publisher = $publisher;
+    }
+
+    /**
+     * Push the new feed in the queue so new items will be fetched instantly.
+     * In case RabbitMQ isn't well configured avoid exception and let the default command fetch new items.
+     *
+     * @param NewFeedEvent $event
+     *
+     * @return bool
+     */
+    public function sync(NewFeedEvent $event)
+    {
+        $message = new Message(json_encode([
+            'feed_id' => $event->getFeed()->getId(),
+        ]));
+
+        try {
+            $this->publisher->publish(
+                'f43.fetch_items.publisher',
+                $message
+            );
+
+            return true;
+        } catch (AMQPExceptionInterface $e) {
+            return false;
+        }
+    }
+}

--- a/src/AppBundle/EventListener/ItemSubscriber.php
+++ b/src/AppBundle/EventListener/ItemSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\EventListener;
 
-use AppBundle\Event\ItemEvent;
+use AppBundle\Event\ItemsCachedEvent;
 use Http\Client\Common\HttpMethodsClientInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -32,11 +32,11 @@ class ItemSubscriber
      *
      * http://nathangrigg.net/2012/09/real-time-publishing/
      *
-     * @param ItemEvent $event
+     * @param ItemsCachedEvent $event
      *
      * @return bool
      */
-    public function pingHub(ItemEvent $event)
+    public function pingHub(ItemsCachedEvent $event)
     {
         if (empty($this->hub)) {
             return false;

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -84,15 +84,6 @@ services:
             - "@doctrine.odm.mongodb.document_manager"
             - "@router"
 
-    item.ping_hub:
-        class: AppBundle\EventListener\ItemSubscriber
-        arguments:
-            - "http://pubsubhubbub.appspot.com"
-            - "@router"
-            - "@httplug.client.default.http_methods"
-        tags:
-            - { name: kernel.event_listener, event: api43_feed.after_item_cached, method: pingHub }
-
     # validator
     validator.rss.valid_rss:
         class: AppBundle\Validator\Constraints\ConstraintRssValidator

--- a/tests/AppBundle/Consumer/FetchItemsTest.php
+++ b/tests/AppBundle/Consumer/FetchItemsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\AppBundle\Consumer;
+
+use AppBundle\Consumer\FetchItems;
+use AppBundle\Entity\Feed;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Psr\Log\NullLogger;
+use Swarrot\Broker\Message;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class FetchItemsTest extends WebTestCase
+{
+    public function testProcessNoFeed()
+    {
+        static::createClient();
+
+        /** @var \Symfony\Component\DependencyInjection\ContainerInterface */
+        $container = self::$kernel->getContainer();
+
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $contentImport = $this->getMockBuilder('AppBundle\Content\Import')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $feedRepository = $this->getMockBuilder('AppBundle\Repository\FeedRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $feedRepository->expects($this->once())
+            ->method('find')
+            ->with(123)
+            ->willReturn(null);
+
+        $processor = new FetchItems(
+            $doctrine,
+            $feedRepository,
+            $contentImport,
+            $container->get('router.test'),
+            new NullLogger(),
+            'f43.io'
+        );
+
+        $processor->process(new Message(json_encode(['feed_id' => 123])), []);
+    }
+
+    public function testProcessSuccessfulMessage()
+    {
+        static::createClient();
+
+        /** @var \Symfony\Component\DependencyInjection\ContainerInterface */
+        $container = self::$kernel->getContainer();
+
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $em->expects($this->once())
+            ->method('isOpen')
+            ->willReturn(false); // simulate a closing manager
+
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $doctrine->expects($this->once())
+            ->method('getEntityManager')
+            ->willReturn($em);
+        $doctrine->expects($this->once())
+            ->method('resetEntityManager')
+            ->willReturn($em);
+
+        $contentImport = $this->getMockBuilder('AppBundle\Content\Import')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $contentImport->expects($this->once())
+            ->method('setEntityManager');
+        $contentImport->expects($this->once())
+            ->method('process')
+            ->willReturn(3);
+
+        $feed = new Feed();
+        $feed->setId(123);
+        $feed->setSlug('reddit');
+
+        $feedRepository = $this->getMockBuilder('AppBundle\Repository\FeedRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $feedRepository->expects($this->once())
+            ->method('find')
+            ->with(123)
+            ->willReturn($feed);
+
+        $logger = new Logger('foo');
+        $logHandler = new TestHandler();
+        $logger->pushHandler($logHandler);
+
+        $processor = new FetchItems(
+            $doctrine,
+            $feedRepository,
+            $contentImport,
+            $container->get('router.test'),
+            $logger,
+            'f43.io'
+        );
+
+        $processor->process(new Message(json_encode(['feed_id' => 123])), []);
+
+        $records = $logHandler->getRecords();
+
+        $this->assertSame('Consume f43.feed_new message', $records[0]['message']);
+        $this->assertSame('<comment>3</comment> items cached for <info>reddit</info>', $records[1]['message']);
+    }
+}

--- a/tests/AppBundle/EventListener/FeedSubscriberTest.php
+++ b/tests/AppBundle/EventListener/FeedSubscriberTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\AppBundle\EventListener;
+
+use AppBundle\Entity\Feed;
+use AppBundle\Event\NewFeedEvent;
+use AppBundle\EventListener\FeedSubscriber;
+use PhpAmqpLib\Exception\AMQPIOException;
+use Tests\AppBundle\AppTestCase;
+
+class FeedSubscriberTest extends AppTestCase
+{
+    public function testOnFeedCreated()
+    {
+        $publisher = $this->getMockBuilder('Swarrot\SwarrotBundle\Broker\Publisher')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $publisher->expects($this->once())
+            ->method('publish');
+
+        $feedSubscriber = new FeedSubscriber($publisher);
+
+        $feed = new Feed();
+        $feed->setId(123);
+
+        $event = new NewFeedEvent($feed);
+
+        $res = $feedSubscriber->sync($event);
+
+        $this->assertTrue($res);
+    }
+
+    public function testOnFeedCreatedNoRabbitMQ()
+    {
+        $publisher = $this->getMockBuilder('Swarrot\SwarrotBundle\Broker\Publisher')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->will($this->throwException(new AMQPIOException()));
+
+        $feedSubscriber = new FeedSubscriber($publisher);
+
+        $feed = new Feed();
+        $feed->setId(123);
+
+        $event = new NewFeedEvent($feed);
+
+        $res = $feedSubscriber->sync($event);
+
+        $this->assertFalse($res);
+    }
+}

--- a/tests/AppBundle/EventListener/ItemSubscriberTest.php
+++ b/tests/AppBundle/EventListener/ItemSubscriberTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\AppBundle\EventListener;
 
-use AppBundle\Event\ItemEvent;
+use AppBundle\Event\ItemsCachedEvent;
 use AppBundle\EventListener\ItemSubscriber;
 use GuzzleHttp\Psr7\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -20,7 +20,7 @@ class ItemSubscriberTest extends AppTestCase
 
         $itemSubscriber = new ItemSubscriber('', $router, $client);
 
-        $event = new ItemEvent(['bar.unknown']);
+        $event = new ItemsCachedEvent(['bar.unknown']);
         $res = $itemSubscriber->pingHub($event);
 
         // the hub url is invalid, so it will be generate an error and return false
@@ -42,7 +42,7 @@ class ItemSubscriberTest extends AppTestCase
 
         $itemSubscriber = new ItemSubscriber('http://f43.me', $router, $client);
 
-        $event = new ItemEvent(['bar.unknown']);
+        $event = new ItemsCachedEvent(['bar.unknown']);
         $res = $itemSubscriber->pingHub($event);
 
         // the hub url is invalid, so it will be generate an error and return false
@@ -64,7 +64,7 @@ class ItemSubscriberTest extends AppTestCase
 
         $itemSubscriber = new ItemSubscriber('http://f43.me', $router, $client);
 
-        $event = new ItemEvent(['bar.unknown']);
+        $event = new ItemsCachedEvent(['bar.unknown']);
         $res = $itemSubscriber->pingHub($event);
 
         $this->assertTrue($res);


### PR DESCRIPTION
The current command to fetch items will still exist.
It'll now have an option to send each feed id to a queue.
Fetching new items will be faster and safer. We'll no longer have a locked command because a feed took too much time to respond.