### PR TITLE
Rewrote the way to override site config when testing

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -79,10 +79,6 @@ services:
         arguments:
             -
                 error_message: false
-                extractor:
-                    config_builder:
-                        site_config:
-                            - "%kernel.project_dir%/data/site_config"
         calls:
             - [ setLogger, [ "@logger" ] ]
         tags:

--- a/src/Controller/TestController.php
+++ b/src/Controller/TestController.php
@@ -29,6 +29,7 @@ class TestController extends AbstractController
 
         $filePath = '';
         $content = null;
+        $previousVersion = null;
 
         if ($form->isSubmitted() && $form->isValid()) {
             // load custom siteconfig from user
@@ -44,7 +45,13 @@ class TestController extends AbstractController
                         $host = substr($host, 4);
                     }
 
-                    $filePath = $this->getParameter('kernel.project_dir') . '/data/site_config/' . $host . '.txt';
+                    $filePath = $this->getParameter('kernel.project_dir') . '/vendor/j0k3r/graby-site-config/' . $host . '.txt';
+
+                    if (file_exists($filePath)) {
+                        $previousVersion = file_get_contents($filePath);
+                        $siteConfig = $previousVersion . "\n" . $siteConfig;
+                    }
+
                     file_put_contents($filePath, $siteConfig);
                 }
             }
@@ -55,7 +62,11 @@ class TestController extends AbstractController
                 ->parseContent($form->get('link')->getData());
 
             if ($filePath) {
-                unlink($filePath);
+                if ($previousVersion) {
+                    file_put_contents($filePath, $previousVersion);
+                } else {
+                    unlink($filePath);
+                }
             }
         }
 

--- a/tests/Controller/TestControllerTest.php
+++ b/tests/Controller/TestControllerTest.php
@@ -28,7 +28,7 @@ class TestControllerTest extends FeedWebTestCase
         $form = $crawler->filter('form.custom button[type=submit]')->form();
 
         $crawler = $client->submit($form, [
-            'item_test[link]' => 'http://www.lemonde.fr/planete/article/2015/12/16/bisphenol-a-phtalates-pesticides-bruxelles-condamnee-pour-son-inaction_4833090_3244.html',
+            'item_test[link]' => 'https://www.lemonde.fr/planete/article/2015/12/16/bisphenol-a-phtalates-pesticides-bruxelles-condamnee-pour-son-inaction_4833090_3244.html',
             'item_test[parser]' => 'internal',
         ]);
 
@@ -46,7 +46,26 @@ class TestControllerTest extends FeedWebTestCase
         $form = $crawler->filter('form.custom button[type=submit]')->form();
 
         $crawler = $client->submit($form, [
-            'item_test[link]' => 'http://www.lemonde.fr/planete/article/2015/12/16/bisphenol-a-phtalates-pesticides-bruxelles-condamnee-pour-son-inaction_4833090_3244.html',
+            'item_test[link]' => 'https://www.lemonde.fr/planete/article/2015/12/16/bisphenol-a-phtalates-pesticides-bruxelles-condamnee-pour-son-inaction_4833090_3244.html',
+            'item_test[parser]' => 'internal',
+            'item_test[siteconfig]' => 'body: //body',
+        ]);
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertCount(1, $crawler->filter('ul.no-bullet'));
+        $this->assertStringNotContainsString('We failed to make this item readable, the default text from the feed item will be displayed instead.', (string) $client->getResponse()->getContent());
+    }
+
+    public function testFeedTestSubmitWithSiteConfigNonExistent(): void
+    {
+        $client = static::getAuthorizedClient();
+
+        $crawler = $client->request('GET', '/feed/test');
+
+        $form = $crawler->filter('form.custom button[type=submit]')->form();
+
+        $crawler = $client->submit($form, [
+            'item_test[link]' => 'https://bandito.re',
             'item_test[parser]' => 'internal',
             'item_test[siteconfig]' => 'body: //body',
         ]);


### PR DESCRIPTION
Look likes that feature doesn't really works 🤔
At least, if the given domain already has a site config defined in graby-site-config, it was impossible to add more config to it.

Now, config which is tested is merged in the existing file (or the file is created) and after the test, the file is reverted (or deleted if it doesn't exist first).