### PR TITLE
Allow PostgreSQL to be used as database

### DIFF
--- a/.env
+++ b/.env
@@ -50,8 +50,9 @@ APP_SECRET=951e2173ffafecadc57cbbb2263567ea
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
 #
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
-# DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7"
-DATABASE_URL=mysql://root:root@127.0.0.1:3306/f43me
+# DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7&charset=utf8mb4"
+# DATABASE_URL=postgresql://postgres:root@localhost:5432/f43me?serverVersion=14&charset=utf8
+DATABASE_URL=mysql://root:root@127.0.0.1:3306/f43me?serverVersion=5.7&charset=utf8mb4
 ###< doctrine/doctrine-bundle ###
 
 ###> sentry/sentry-symfony ###

--- a/.env.test
+++ b/.env.test
@@ -2,7 +2,7 @@
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999
-DATABASE_URL=mysql://root:@127.0.0.1:3306/f43_test
+DATABASE_URL=mysql://root:@127.0.0.1:3306/f43_test?serverVersion=5.7&charset=utf8mb4
 MERCURY_URL=https://mercury.f43.me
 PANTHER_APP_ENV=panther
 PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,8 +12,8 @@ env:
   fail-fast: true
 
 jobs:
-  phpunit:
-    name: PHPUnit (PHP ${{ matrix.php }})
+  mysql:
+    name: PHPUnit (PHP ${{ matrix.php }} with MySQL)
     runs-on: "ubuntu-20.04"
     services:
       mysql:
@@ -27,6 +27,9 @@ jobs:
         image: rabbitmq:3-alpine
         ports:
           - 5672:5672
+
+    env:
+      DATABASE_URL: mysql://root:@127.0.0.1:3306/f43_test?serverVersion=5.7&charset=utf8mb4
 
     strategy:
       matrix:
@@ -47,6 +50,70 @@ jobs:
           php-version: "${{ matrix.php }}"
           tools: pecl, composer:v2
           extensions: pdo, pdo_mysql, curl, amqp
+          ini-values: "date.timezone=Europe/Paris"
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies with Composer
+        uses: ramsey/composer-install@v2
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install dependencies with Yarn
+        run: yarn install && yarn dev
+
+      - name: Setup messenger queue
+        run: php bin/console messenger:setup-transports --env=dev
+
+      - name: Prepare database
+        run: make prepare
+
+      - name: Prepare logs
+        run: mkdir -p build/logs
+
+      - name: Run PHPUnit
+        run: php bin/simple-phpunit -v
+
+  postgresql:
+    name: PHPUnit (PHP ${{ matrix.php }} with PostgreSQL)
+    runs-on: "ubuntu-20.04"
+    services:
+      postgres:
+        image: postgres:14-alpine
+        env:
+          POSTGRES_PASSWORD: root
+        ports:
+          - 5432:5432
+      rabbitmq:
+        image: rabbitmq:3-alpine
+        ports:
+          - 5672:5672
+
+    env:
+      DATABASE_URL: postgresql://postgres:root@localhost:5432/f43me?serverVersion=14&charset=utf8
+
+    strategy:
+      matrix:
+        php:
+          - "7.4"
+          - "8.0"
+          - "8.1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ matrix.php }}"
+          tools: pecl, composer:v2
+          extensions: pdo, pdo_pgsql, curl, amqp
           ini-values: "date.timezone=Europe/Paris"
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /bin/*
 !/bin/console
 /data/mysql
+/data/pgsql
 /templates/lib
 /public/build
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ When it grabs a new item, there are several steps before we can say the item *is
 
 All of them works in a chain, we'll go thru all of them until we find one that match.
 
-> For curious people, this workflow happen in the [`Extractor->parseContent`](https://github.com/j0k3r/f43.me/blob/000dd43db9ab4429344918a2263bee3bf8aace24/src/AppBundle/Content/Extractor.php#L68) method.
+> For curious people, this workflow happen in the [`Extractor->parseContent`](https://github.com/j0k3r/f43.me/blob/e5b88b8e9c51933f7fd8ea4c2b06916e6c4a5135/src/Content/Extractor.php#L87) method.
 
 ### Improvers
 
@@ -62,7 +62,7 @@ An improver use 3 methods:
  * `updateUrl`: can do whatever it wants to update the url of an item (for Reddit, we extract the url from the `[link]`)
  * `updateContent`: add interesting information previous (or after) the readable content (for  Reddit we just put the readable content **after** the item content. *This method will be called AFTER the parser described below.*
 
-You can find some examples in the [improver folder](https://github.com/j0k3r/f43.me/tree/master/src/AppBundle/Improver) (atm Reddit & HackerNews).
+You can find some examples in the [improver folder](https://github.com/j0k3r/f43.me/tree/master/src/Improver) (atm Reddit & HackerNews).
 
 ### Extractors
 
@@ -75,7 +75,7 @@ An extractor uses 2 methods:
  * `match`: tells if this extractor needs to work on that item (usually a bunch of regex & host matching)
  * `getContent`: it will call the related API or url to fetch the content from the match parameters found in the `match` method (like Twitter ID, Flickr ID, etc...) and return a clean html
 
-You can find some of them in the [extractor folder](https://github.com/j0k3r/f43.me/tree/master/src/AppBundle/Extractor) (Flickr, Twitter, Github, etc...)
+You can find some of them in the [extractor folder](https://github.com/j0k3r/f43.me/tree/master/src/Extractor) (Flickr, Twitter, GitHub, etc...)
 
 ### Parsers
 
@@ -92,7 +92,7 @@ And finally, we can use some converters to transform HTML code to something diff
 
 For example, Instagram embed code doesn't include the image itself (this part is usually done in javascript). The Instagram converter use the Instagram extractor to retrieve the image of an embed code and put it back in the feed item content.
 
-You can find some of them in the [converter folder](https://github.com/j0k3r/f43.me/tree/master/src/AppBundle/Converter) (only Instagram for the moment)
+You can find some of them in the [converter folder](https://github.com/j0k3r/f43.me/tree/master/src/Converter) (only Instagram for the moment)
 
 ## How to use it
 
@@ -188,10 +188,10 @@ php /path/to/f43.me/bin/console feed:fetch-items --env=prod --slug=reddit -t
 You can use the built-in Docker image using `docker-compose`:
 
 ```bash
-docker-compose up --build
+docker-compose up
 ```
 
-You should be able to access the interface using `http://localhost:8100/app_dev.php`
+You should be able to access the interface using `http://localhost:8100/index.php`
 
 ## License
 

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -2,12 +2,6 @@ doctrine:
     dbal:
         url: '%env(resolve:DATABASE_URL)%'
 
-        # IMPORTANT: You MUST configure your server version,
-        # either here or in the DATABASE_URL env var (see .env file)
-        server_version: '5.7'
-
-        # only needed for MySQL
-        charset: utf8mb4
         default_table_options:
             charset: utf8mb4
             collate: utf8mb4_unicode_ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,26 @@
-version: '3'
+version: '3.1'
 services:
+  # database:
+  #   image: mariadb:10
+  #   ports:
+  #     - "3306:3306"
+  #   volumes:
+  #     - ./data/mysql:/var/lib/mysql:rw
+  #   environment:
+  #     MARIADB_ROOT_PASSWORD: root
+  #   restart: always
+
   database:
-    image: mariadb:10
+    image: postgres:14-alpine
     ports:
-      - "3306:3306"
+      - 5432:5432
     volumes:
-      - ./data/mysql:/var/lib/mysql:rw
+      - ./data/pgsql:/var/lib/postgresql/data
     environment:
-      MARIADB_ROOT_PASSWORD: root
+      POSTGRES_PASSWORD: root
     restart: always
 
-  nginx-php7.2:
+  nginx-php:
     build:
       context: ./docker
       dockerfile: ./Dockerfile-php7.4


### PR DESCRIPTION
This will require existing installation to update their `DATABASE_URL` to include both:
- the `serverVersion` (for example: 5.7 for MySQL and 14 for PostgreSQL)
- the `charset` (for MySQL: utf8mb4, for PostgreSQL: utf8)

Should fix https://github.com/j0k3r/f43.me/issues/1083

Also fix dead links in README