### PR TITLE
Allow auto merging of Dependabot JS minor or patch

### DIFF
--- a/.github/workflows/dependabot-automerge-js.yml
+++ b/.github/workflows/dependabot-automerge-js.yml
@@ -1,0 +1,25 @@
+name: Auto-merge Dependabot JS
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Approve and merge minor updates
+        if: ${{ steps.metadata.outputs.package-ecosystem == 'npm_and_yarn' && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reducing the time consuming of merging deps which shouldn't break the project