### PR TITLE
Add missing sentry service

### DIFF
--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -13,6 +13,7 @@ when@prod:
         handlers:
             sentry:
                 type: service
+                id: Sentry\Monolog\Handler
                 level: !php/const Monolog\Logger::ERROR
                 hub_id: Sentry\State\HubInterface
 


### PR DESCRIPTION
Avoid error:

>   Invalid configuration for path "monolog.handlers.sentry": The id has to be specified to use a service as handler