### PR TITLE
Add ability to replace existing siteconfig when testing

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -10,9 +10,11 @@ if (document.querySelectorAll('.time-ago').length > 0) {
 // handle show / hide of the textarea when testing config file
 const siteconfig = document.getElementById('siteconfig')
 if (siteconfig !== null) {
-    const siteconfigTextarea = siteconfig.childNodes[3]
+    const siteconfigTextarea = siteconfig.querySelector('textarea')
+    const siteconfigCheckboxDiv = siteconfig.querySelector('div')
     if (siteconfigTextarea.value === '') {
         siteconfigTextarea.style.display = 'none'
+        siteconfigCheckboxDiv.style.display = 'none'
     }
 
     document.getElementById('try-siteconfig').onclick = function (event) {
@@ -24,8 +26,10 @@ if (siteconfig !== null) {
 
         if (siteconfigTextarea.style.display === 'none') {
             siteconfigTextarea.style.display = 'block'
+            siteconfigCheckboxDiv.style.display = 'block'
         } else {
             siteconfigTextarea.style.display = 'none'
+            siteconfigCheckboxDiv.style.display = 'none'
         }
 
         return false

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -147,3 +147,7 @@ iframe.pubsubhubbub {
     overflow-y: scroll;
     align-items: flex-start;
 }
+
+label.label-no-block {
+    display: inline-block;
+}

--- a/src/Controller/TestController.php
+++ b/src/Controller/TestController.php
@@ -34,6 +34,7 @@ class TestController extends AbstractController
             // load custom siteconfig from user
             // add ability to test a siteconfig before submitting it
             $siteConfig = $form->get('siteconfig')->getData();
+            $replaceCurrentSiteconfig = $form->get('siteconfig_replace')->getData();
             if (trim((string) $siteConfig)) {
                 $host = parse_url((string) $form->get('link')->getData(), \PHP_URL_HOST);
 
@@ -48,7 +49,10 @@ class TestController extends AbstractController
 
                     if (file_exists($filePath)) {
                         $previousVersion = file_get_contents($filePath);
-                        $siteConfig = $previousVersion . "\n" . $siteConfig;
+
+                        if (!$replaceCurrentSiteconfig) {
+                            $siteConfig = $previousVersion . "\n" . $siteConfig;
+                        }
                     }
 
                     file_put_contents($filePath, $siteConfig);

--- a/src/Form/Type/ItemTestType.php
+++ b/src/Form/Type/ItemTestType.php
@@ -3,6 +3,7 @@
 namespace App\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
@@ -26,6 +27,10 @@ class ItemTestType extends AbstractType
                     'internal' => 'Internal',
                     'external' => 'External',
                 ]),
+            ])
+            ->add('siteconfig_replace', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Replace existing site config for the given host',
             ])
         ;
     }

--- a/templates/default/Test/index.html.twig
+++ b/templates/default/Test/index.html.twig
@@ -27,6 +27,11 @@
             <p><a href="#" id="try-siteconfig">Want to try a custom siteconfig?</a> A tool is <a target="_blank" href="http://siteconfig.fivefilters.org/">available</a> to help build site-specific extraction rules.</p>
 
             {{ form_widget(form.siteconfig, {'attr': { 'placeholder': 'Put your config file here'}}) }}
+
+            <div>
+                {{ form_label(form.siteconfig_replace, null, {'label_attr': {'class': 'label-no-block'}}) }}
+                {{ form_widget(form.siteconfig_replace) }}
+            </div>
         </div>
 
         {{ form_rest(form) }}


### PR DESCRIPTION
It'll allow (in case of the existing siteconfig is for example badly written) to replace the existing siteconfig with the one given in the form. The original one will be put back after the fetch.

Should fix https://github.com/j0k3r/f43.me/issues/1366

<img width="1410" height="1072" alt="image" src="https://github.com/user-attachments/assets/12f3592a-fe6f-469c-9b3b-1e38aa8d6321" />

Poke @HolgerAusB